### PR TITLE
fix: ensure updateActor hook triggers on zero pv

### DIFF
--- a/module/daemonrpg.mjs
+++ b/module/daemonrpg.mjs
@@ -233,8 +233,8 @@ Hooks.on("renderChatMessage", (chatMessage, html, messageData) => {
 
 // Hook para remover o status de inconsciente quando o personagem recupera PVs acima de 0
 Hooks.on("updateActor", (actor, changes, options, userId) => {
-  if (!changes.system?.resources?.pv?.value) return;
-  
+  if (!foundry.utils.hasProperty(changes, "system.resources.pv.value")) return;
+
   const newPV = changes.system.resources.pv.value;
   
   // Se os PVs foram restaurados para acima de 0, remove o efeito de inconsciente


### PR DESCRIPTION
## Summary
- fix updateActor hook to run when pv.value is 0 by checking property existence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68917bb6b1ac8321af00b4d65619dfd5