### PR TITLE
Replace deprecated async roll evaluation

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -82,7 +82,7 @@ export class DaemonItem extends Item {
       case "arma":
         flavor = `Rolando Dano: <strong>${this.name}</strong>`;
         const danoRoll = new Roll(this.system.damage, this.actor.getRollData());
-        await danoRoll.evaluate({ async: true });
+        await danoRoll.evaluate();
 
         // LÓGICA CONDICIONAL DO BÔNUS DE FORÇA
         let bonusDano = 0;
@@ -116,7 +116,7 @@ export class DaemonItem extends Item {
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     const rollMode = game.settings.get("core", "rollMode");
     const roll = new Roll("1d100");
-    await roll.evaluate({ async: true });
+    await roll.evaluate();
     const success = roll.total <= valorAlvo && roll.total <= 95;
     let flavor = `Teste de Perícia: <strong>${this.name}</strong>`;
     flavor += success ? ` (Sucesso!)` : ` (Falha!)`;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -199,7 +199,7 @@ export class DaemonActorSheet extends ActorSheet {
               parseInt(html.find('[name="defesaAlvo"]').val()) || 0;
             const chance = 50 + ataquePersonagem - defesaAlvo;
             const roll = new Roll("1d100");
-            await roll.evaluate({ async: true });
+            await roll.evaluate();
             const critico = Math.floor(ataquePersonagem / 4);
             const isSuccess = roll.total <= chance && roll.total <= 95;
             const isCritical = roll.total <= critico;
@@ -239,7 +239,7 @@ export class DaemonActorSheet extends ActorSheet {
                   danoFormula,
                   this.actor.getRollData()
                 );
-                await danoRoll.evaluate({ async: true });
+                await danoRoll.evaluate();
                 let bonusDano = 0;
                 let formulaDisplay = danoRoll.formula;
                 if (armaUsada.system.weaponType === "corporal") {
@@ -303,7 +303,7 @@ export class DaemonActorSheet extends ActorSheet {
     const attributeName = dataset.label;
     const realizarTesteAtributo = async (valorAlvo) => {
       const roll = new Roll("1d100");
-      await roll.evaluate({ async: true });
+      await roll.evaluate();
       const success = roll.total <= valorAlvo && roll.total <= 95;
       let flavor = `Teste de <strong>${attributeName}</strong>`;
       flavor += success ? ` (Sucesso!)` : ` (Falha!)`;
@@ -479,7 +479,7 @@ export class DaemonActorSheet extends ActorSheet {
     
     // Realiza a rolagem
     const roll = new Roll("1d100");
-    await roll.evaluate({ async: true });
+    await roll.evaluate();
     
     // Determina o sucesso
     const isSuccess = roll.total <= successChance;


### PR DESCRIPTION
## Summary
- remove deprecated `{ async: true }` option from `Roll#evaluate`
- update actor and item roll handlers to use `await roll.evaluate()`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68918e3e2bf083219ad0e9f8aaea20ad