### PR TITLE
feat: add configurable creation points

### DIFF
--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -19,6 +19,20 @@
     "SheetLabels": {
       "Actor": "Ficha de Personagem Daemon",
       "Item": "Ficha de Item Daemon"
+    },
+    "Settings": {
+      "creationAttributePoints": {
+        "Name": "Pontos iniciais de atributos",
+        "Hint": "Quantidade de pontos de atributo disponíveis na criação de personagens."
+      },
+      "creationPositiveAprimoramentos": {
+        "Name": "Aprimoramentos positivos iniciais",
+        "Hint": "Quantidade de pontos de aprimoramentos positivos disponíveis na criação de personagens."
+      },
+      "creationNegativeAprimoramentos": {
+        "Name": "Aprimoramentos negativos iniciais",
+        "Hint": "Quantidade de pontos de aprimoramentos negativos permitidos na criação de personagens."
+      }
     }
   }
 }

--- a/module/daemonrpg.mjs
+++ b/module/daemonrpg.mjs
@@ -71,6 +71,34 @@ Hooks.once("init", function () {
   // if the transfer property on the Active Effect is true.
   CONFIG.ActiveEffect.legacyTransferral = false;
 
+  // Register system settings
+  game.settings.register("daemonrpg", "creationAttributePoints", {
+    name: "daemonrpg.Settings.creationAttributePoints.Name",
+    hint: "daemonrpg.Settings.creationAttributePoints.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 101,
+  });
+
+  game.settings.register("daemonrpg", "creationPositiveAprimoramentos", {
+    name: "daemonrpg.Settings.creationPositiveAprimoramentos.Name",
+    hint: "daemonrpg.Settings.creationPositiveAprimoramentos.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 5,
+  });
+
+  game.settings.register("daemonrpg", "creationNegativeAprimoramentos", {
+    name: "daemonrpg.Settings.creationNegativeAprimoramentos.Name",
+    hint: "daemonrpg.Settings.creationNegativeAprimoramentos.Hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 3,
+  });
+
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);
   Actors.registerSheet("daemonrpg", DaemonActorSheet, {
@@ -103,6 +131,28 @@ Handlebars.registerHelper("toLowerCase", function (str) {
 Hooks.once("ready", function () {
   // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
   Hooks.on("hotbarDrop", (bar, data, slot) => createItemMacro(data, slot));
+});
+
+// Set initial creation values based on system settings
+Hooks.on("preCreateActor", (actor) => {
+  if (actor.type !== "personagem") return;
+  const attrPts = game.settings.get(
+    "daemonrpg",
+    "creationAttributePoints"
+  );
+  const posAprim = game.settings.get(
+    "daemonrpg",
+    "creationPositiveAprimoramentos"
+  );
+  const negAprim = game.settings.get(
+    "daemonrpg",
+    "creationNegativeAprimoramentos"
+  );
+  actor.updateSource({
+    "system.details.creation.attribute_points": attrPts,
+    "system.details.creation.aprimoramentos_pos": posAprim,
+    "system.details.creation.aprimoramentos_neg": negAprim,
+  });
 });
 
 /* -------------------------------------------- */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -85,7 +85,13 @@ export class DaemonActor extends Actor {
     }
     systemData.details.aprimoramentos.positivos = pontosPositivos;
     systemData.details.aprimoramentos.negativos = Math.abs(pontosNegativos);
-    const pontosIniciais = 5;
+    const pontosIniciais =
+      systemData.details.creation?.aprimoramentos_pos ??
+      game.settings.get(
+        "daemonrpg",
+        "creationPositiveAprimoramentos"
+      );
+    systemData.details.aprimoramentos.iniciais = pontosIniciais;
     systemData.details.aprimoramentos.disponivel =
       pontosIniciais +
       systemData.details.aprimoramentos.negativos -

--- a/templates/actor/personagem-sheet.hbs
+++ b/templates/actor/personagem-sheet.hbs
@@ -564,7 +564,7 @@
         <h4>Balanço de Pontos</h4>
         <div class="stat">
           <label>Pontos Iniciais:</label>
-          <span class="stat-value">5</span>
+          <span class="stat-value">{{system.details.aprimoramentos.iniciais}}</span>
         </div>
         <div class="stat">
           <label>Pontos de Desvantagens:</label>


### PR DESCRIPTION
## Summary
- allow GMs to configure starting attribute and enhancement points
- display configured initial enhancement points on actor sheet
- localize new system settings

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68918fca43248321941fd44d19c80a05